### PR TITLE
DSO-855-add-sbt-dependency-graph-plugin

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addDependencyTreePlugin


### PR DESCRIPTION
SBT SCAN FAILURE: SBT_PLUGIN_MISSING: Sbt Native Inspector
 

[Synopsys Software Integrity Customer Community](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=packagemgrs%2Fsbt.html&_LANG=enus) 

Synopsys Detect runs the dependecyDot task when it finds the following in your project
build.sbt

The SBT detector requires a compatible dependency graph plugin and the "depedencyDot" task to generate dependency graphs for SBT projects. The plugin generates dot file graphs for each project and Synopsys Detect parses each dot graph into it's own code location.

Starting with SBT 1.4.0, a dependency graph plugin comes with SBT and can be enabled by adding addDependencyTreePlugin to "project/plugins.sbt".

